### PR TITLE
Link to Ember.Logger

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,23 @@
+{
+    "env": {
+        "browser": true,
+        "commonjs": true,
+        "es6": true,
+        "node": true
+    },
+    "parserOptions": {
+        "ecmaFeatures": {
+            "jsx": true
+        },
+        "sourceType": "module"
+    },
+    "rules": {
+        "no-const-assign": "warn",
+        "no-this-before-super": "warn",
+        "no-undef": "warn",
+        "no-unreachable": "warn",
+        "no-unused-vars": "warn",
+        "constructor-super": "warn",
+        "valid-typeof": "warn"
+    }
+}

--- a/addon/initializers/rollbar.js
+++ b/addon/initializers/rollbar.js
@@ -1,47 +1,54 @@
 /* global Rollbar */
 import Ember from 'ember';
 
+const {
+  Logger,
+  typeOf
+} = Ember;
+
+const stringify = function (object) {
+  return JSON ? JSON.stringify(object) : object.toString();
+};
+
+const isError = function (object) {
+  return typeOf(object) === 'error';
+};
+
 export default {
   name: 'rollbar',
-  initialize: function() {
-    var errorLogger = Ember.Logger.error;
-    Ember.Logger.error = function() {
-      var args = Array.prototype.slice.call(arguments),
-          err = isError(args[0]) ? args[0] : new Error(stringify(args));
 
-      if (window.Rollbar) {
+  initialize: function () {
+    var errorLogger = Logger.error;
+    Logger.error = function (...args) {
+      let err = isError(args[0]) ? args[0] : new Error(stringify(args));
+      if (Rollbar) {
         Rollbar.error.call(Rollbar, err);
       }
       errorLogger.apply(this, arguments);
     };
-    var warnLogger = Ember.Logger.warn;
-    Ember.Logger.warn = function() {
-      if (window.Rollbar) {
+
+    var warnLogger = Logger.warn;
+    Logger.warn = function () {
+      if (Rollbar) {
         Rollbar.warning.apply(Rollbar, arguments);
       }
       warnLogger.apply(this, arguments);
     };
-    var infoLogger = Ember.Logger.info;
-    Ember.Logger.info = function() {
-      if (window.Rollbar) {
+
+    var infoLogger = Logger.info;
+    Logger.info = function () {
+      if (Rollbar) {
         Rollbar.info.apply(Rollbar, arguments);
       }
       infoLogger.apply(this, arguments);
     };
-    var debugLogger = Ember.Logger.debug;
-    Ember.Logger.debug = function() {
-      if (window.Rollbar) {
+
+    var debugLogger = Logger.debug;
+    Logger.debug = function () {
+      if (Rollbar) {
         Rollbar.debug.apply(Rollbar, arguments);
       }
       debugLogger.apply(this, arguments);
     };
   }
-};
-
-var stringify = function(object){
-  return JSON ? JSON.stringify(object) : object.toString();
-};
-
-var isError = function(object){
-  return Ember.typeOf(object) === 'error';
 };

--- a/addon/initializers/rollbar.js
+++ b/addon/initializers/rollbar.js
@@ -1,0 +1,47 @@
+/* global Rollbar */
+import Ember from 'ember';
+
+export default {
+  name: 'rollbar',
+  initialize: function() {
+    var errorLogger = Ember.Logger.error;
+    Ember.Logger.error = function() {
+      var args = Array.prototype.slice.call(arguments),
+          err = isError(args[0]) ? args[0] : new Error(stringify(args));
+
+      if (window.Rollbar) {
+        Rollbar.error.call(Rollbar, err);
+      }
+      errorLogger.apply(this, arguments);
+    };
+    var warnLogger = Ember.Logger.warn;
+    Ember.Logger.warn = function() {
+      if (window.Rollbar) {
+        Rollbar.warning.apply(Rollbar, arguments);
+      }
+      warnLogger.apply(this, arguments);
+    };
+    var infoLogger = Ember.Logger.info;
+    Ember.Logger.info = function() {
+      if (window.Rollbar) {
+        Rollbar.info.apply(Rollbar, arguments);
+      }
+      infoLogger.apply(this, arguments);
+    };
+    var debugLogger = Ember.Logger.debug;
+    Ember.Logger.debug = function() {
+      if (window.Rollbar) {
+        Rollbar.debug.apply(Rollbar, arguments);
+      }
+      debugLogger.apply(this, arguments);
+    };
+  }
+};
+
+var stringify = function(object){
+  return JSON ? JSON.stringify(object) : object.toString();
+};
+
+var isError = function(object){
+  return Ember.typeOf(object) === 'error';
+};

--- a/addon/services/rollbar.js
+++ b/addon/services/rollbar.js
@@ -1,75 +1,17 @@
 /*global Rollbar*/
 import Ember from 'ember';
 
-const {
-  Service,
-  set,
-  RSVP,
-  Logger
-} = Ember;
-
-const GLOBAL_ERRORS = [];
-
-window._getErrors = () => GLOBAL_ERRORS;
-window._resetErrors = () => GLOBAL_ERRORS.length = 0;
-
-const reportError = (...args) => {
-  const [ err ] = args;
-  
-  // next allow do not report to rollbar if key is empty
-  const { options: { accessToken, rollbarKey } } = Rollbar; 
-  if (accessToken || rollbarKey) {
-    Rollbar.error.apply(Rollbar, args);
-  }
-  
-  // By default `JSON.stringify` for `Error` instance return `{}`. Replace it with `error.stack`
-  if (err instanceof Error) {
-    const { stack } = err;
-    args[0] = stack;
-  }
-
-  GLOBAL_ERRORS.push(JSON.parse(JSON.stringify(args)));
-};
-
-const reportEmberErrorToRollbar = (error, source) => {
-  Logger.error(error);
-  if (error instanceof Error) {
-    reportError(error, { emberSource: `${source} with error object` });
-  } else if (error) {
-    if (error.message && error.name) {
-      reportError(`${error.name}: ${error.message}`,
-        { origError: error, emberSource: `${source} with non-error instance` });
-    } else {
-      reportError(error, { emberSource: `${source} with non-error instance` });
-    }
-  } else {
-    reportError('Error is undefined', { emberSource: `${source} default` });
-  }
-};
-
-export default Service.extend({
+export default Ember.Service.extend({
   rollbar: null,
 
   configure(config = {}) {
-    const onError = Ember.onerror;
-
     if (Rollbar.init) {
       Rollbar.init(config);
     } else {
       Rollbar.configure(config);
     }
 
-    Ember.onerror = (error) => {
-      if (onError) {
-        onError(error);
-      }
-      reportEmberErrorToRollbar(error, 'Ember.onerror');
-    };
-
-    RSVP.on('error', reportEmberErrorToRollbar);
-
-    set(this, 'rollbar', Rollbar);
-
+    Ember.set(this, 'rollbar', Rollbar);
     return Rollbar;
   }
 });

--- a/app/initializers/rollbar.js
+++ b/app/initializers/rollbar.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-rollbar/initializers/rollbar';

--- a/blueprints/ember-rollbar/index.js
+++ b/blueprints/ember-rollbar/index.js
@@ -12,6 +12,6 @@ module.exports = {
   // }
 
   afterInstall: function() {
-    return this.addBowerPackageToProject('rollbar', '1.9.1');
+    return this.addBowerPackageToProject('rollbar', '1.9.3');
   }
 };


### PR DESCRIPTION
When I switched from **ember-cli-rollbar** to **ember-rollbar** I become receive `TransitionAborted: TransitionAborted` errors. And I found that you links error reporting to `Ember.onerror`not to `Ember.Logger.<level>` functions. Ember suppress this errors in logger.

+ Added `rollbar` initializer which overwrites `Ember.Logger.<level>` functions from [davewasmer/ember-cli-rollbar](https://github.com/davewasmer/ember-cli-rollbar/blob/master/app/initializers/rollbar.js).
+ Use *rollbar.js* 1.9.3